### PR TITLE
Validate timetable and event times

### DIFF
--- a/parserics/json_to_courses.py
+++ b/parserics/json_to_courses.py
@@ -1,15 +1,18 @@
 from data import Course
 
+
 def json_to_courses(json_data):
     courses = []
     for item in json_data:
-        courses.append(Course(
-            name=item["name"],
-            teacher=item["teacher"],
-            classroom=item["classroom"],
-            location=item.get("location", item["classroom"]),
-            weekday=item["weekday"],
-            weeks=item["weeks"],
-            indexes=item["indexes"],
-        ))
-    return courses 
+        courses.append(
+            Course(
+                name=item["name"],
+                teacher=item["teacher"],
+                classroom=item["classroom"],
+                location=item.get("location", item["classroom"]),
+                weekday=item["weekday"],
+                weeks=item["weeks"],
+                indexes=sorted(item["indexes"]),
+            )
+        )
+    return courses

--- a/parserics/llm_parser.py
+++ b/parserics/llm_parser.py
@@ -1,6 +1,7 @@
 import os
 from openai import OpenAI
 
+
 def parse_timetable(raw_text, api_key):
     api_key = (api_key or os.getenv("DASHSCOPE_API_KEY") or "").strip()
     client = OpenAI(
@@ -15,17 +16,17 @@ def parse_timetable(raw_text, api_key):
     completion = client.chat.completions.create(
         model="qwen-turbo",
         messages=[
-            {"role": "system", "content": """你是一名严格输出 JSON 的机器人，只能输出json，不能输出其他内容。  
-请遵守以下规则：  
-1. 每条课程记录对应 **一次真实上课事件**（同一课程在不同星期或不同节次需拆成多条）。  
-2. `weekday` 用阿拉伯数字：星期一→1，…，星期日→7。  
-3. `indexes` 必须是升序整数数组；例：“3-4节”→[3,4]。  
-4. `weeks` 要 **全部展开** 成整数数组：  
-   • “[1-16]” → `[1,2,…,16]`  
-   • “[2-16双]” → `[2,4,6,…,16]`  
-   • “[1, 3, 5]” 原样提取 `[1,3,5]`  
-5. 仅在 `location` 与 `classroom` 不同或需更精准定位时填 `location`，否则可以省略（让前端用 `.get("location", classroom)`）。  
-6. 输出示例（请勿直接使用）：  
+            {"role": "system", "content": """你是一名严格输出 JSON 的机器人，只能输出json，不能输出其他内容。
+请遵守以下规则：
+1. 每条课程记录对应 **一次真实上课事件**（同一课程在不同星期或不同节次需拆成多条）。
+2. `weekday` 用阿拉伯数字：星期一→1，…，星期日→7。
+3. `indexes` 必须是升序整数数组；例：“3-4节”→[3,4]。
+4. `weeks` 要 **全部展开** 成整数数组：
+   • “[1-16]” → `[1,2,…,16]`
+   • “[2-16双]” → `[2,4,6,…,16]`
+   • “[1, 3, 5]” 原样提取 `[1,3,5]`
+5. 仅在 `location` 与 `classroom` 不同或需更精准定位时填 `location`，否则可以省略（让前端用 `.get("location", classroom)`）。
+6. 输出示例（请勿直接使用）：
 {
   "courses":[
     {
@@ -44,4 +45,5 @@ def parse_timetable(raw_text, api_key):
         extra_body={"enable_thinking": False},
     )
     # Qwen 返回格式与 OpenAI 兼容
-    return completion.choices[0].message.content 
+    return completion.choices[0].message.content
+

--- a/web.py
+++ b/web.py
@@ -111,12 +111,16 @@ if "course_list" in st.session_state:
     st.dataframe(df, use_container_width=True)
     if st.button("确认无误，生成ICS文件"):
         courses = json_to_courses(st.session_state["course_list"])
-        school = School(
-            duration=duration,
-            timetable=timetable,
-            start=(start_date.year, start_date.month, start_date.day),
-            courses=courses
-        )
-        ics_content = school.generate()
-        st.success("ICS文件已生成！")
-        st.download_button("下载ICS文件", ics_content, file_name="timetable.ics") 
+        try:
+            school = School(
+                duration=duration,
+                timetable=timetable,
+                start=(start_date.year, start_date.month, start_date.day),
+                courses=courses,
+            )
+            ics_content = school.generate()
+        except ValueError as e:
+            st.error(str(e))
+        else:
+            st.success("ICS文件已生成！")
+            st.download_button("下载ICS文件", ics_content, file_name="timetable.ics")


### PR DESCRIPTION
## Summary
- sort and validate course period indexes during initialization
- raise errors when a course's end time is not after its start time and build events with UID/DTSTAMP preceding time fields
- normalize parsed course indexes to maintain ordering

## Testing
- `python -m py_compile data.py web.py parserics/json_to_courses.py parserics/llm_parser.py`


------
https://chatgpt.com/codex/tasks/task_e_68923d9c6894832cb9bc31c5e7db50d4